### PR TITLE
Fix/auth redirects

### DIFF
--- a/api/setup.ts
+++ b/api/setup.ts
@@ -5,14 +5,16 @@ import type { GetTokenOptions } from '@/hooks/session'
 export const setupAPIAuthInterceptors = (getToken: (options?: GetTokenOptions) => Promise<Nullable<string>>) => {
   client.interceptors.request.use(async (config) => {
     if (!['/auth/jwt/refresh/', '/auth/jwt/verify/'].includes(config.url ?? '')) {
-      const token = await getToken()
-
-      if (token) {
-        config.headers = {
-          ...config.headers,
-          Authorization: `JWT ${token}`,
+      try {
+        const token = await getToken()
+        if (token) {
+          config.headers = {
+            ...config.headers,
+            Authorization: `JWT ${token}`,
+          }
         }
-      }
+      } catch {}
+      
     }
     return config
   })

--- a/api/setup.ts
+++ b/api/setup.ts
@@ -2,7 +2,7 @@ import client from './client'
 import { Nullable } from '@/types/common'
 import type { GetTokenOptions } from '@/hooks/session'
 
-export const setupAPIAuthInterceptors = (getToken: (options?: GetTokenOptions) => Promise<Nullable<string>>) => {
+export const setupAPIAuthInterceptors = (getToken: (options?: GetTokenOptions) => Promise<Nullable<string>>, logout: ()=> Promise<void>) => {
   client.interceptors.request.use(async (config) => {
     if (!['/auth/jwt/refresh/', '/auth/jwt/verify/'].includes(config.url ?? '')) {
       try {
@@ -17,5 +17,12 @@ export const setupAPIAuthInterceptors = (getToken: (options?: GetTokenOptions) =
       
     }
     return config
+  })
+
+  client.interceptors.response.use(async (error)=> {
+    if(error.status === 401) {
+      await logout()
+    }
+    return error
   })
 }

--- a/components/guards/RequireLoggedIn.tsx
+++ b/components/guards/RequireLoggedIn.tsx
@@ -31,7 +31,7 @@ export const RequireLoggedIn = ({ Component, pageProps }: AppProps) => {
       }
       setLoading(false)
     }
-    checkUserLoggedIn()
+    if (typeof window !== 'undefined') checkUserLoggedIn()
   }, [Component]); // eslint-disable-line react-hooks/exhaustive-deps
 
   if (loading) {

--- a/components/guards/RequireLoggedIn.tsx
+++ b/components/guards/RequireLoggedIn.tsx
@@ -25,7 +25,7 @@ export const RequireLoggedIn = ({ Component, pageProps }: AppProps) => {
         }
       } else if (AUTH_PATHS.includes(router.pathname)) {
         try {
-          await getToken({ redirect: false })
+          await getToken()
           await router.push('/')
         } catch { }
       }

--- a/components/guards/RequireLoggedIn.tsx
+++ b/components/guards/RequireLoggedIn.tsx
@@ -18,8 +18,11 @@ export const RequireLoggedIn = ({ Component, pageProps }: AppProps) => {
     const checkUserLoggedIn = async () => {
       setLoading(true)
       if (!NO_LOGIN_REQUIRED_PATHS.includes(router.pathname)) {
-        const token = await getToken()
-        if (!token) await logout()
+        try {
+          await getToken()
+        } catch {
+          await logout()
+        }
       } else if (AUTH_PATHS.includes(router.pathname)) {
         try {
           await getToken({ redirect: false })

--- a/components/guards/RequireLoggedIn.tsx
+++ b/components/guards/RequireLoggedIn.tsx
@@ -10,7 +10,7 @@ const NO_LOGIN_REQUIRED_PATHS = [...AUTH_PATHS, ...OPEN_PATHS]
 
 export const RequireLoggedIn = ({ Component, pageProps }: AppProps) => {
   const router = useRouter()
-  const { getToken } = useSession()
+  const { getToken, logout } = useSession()
 
   const [loading, setLoading] = useState(true)
 
@@ -18,7 +18,8 @@ export const RequireLoggedIn = ({ Component, pageProps }: AppProps) => {
     const checkUserLoggedIn = async () => {
       setLoading(true)
       if (!NO_LOGIN_REQUIRED_PATHS.includes(router.pathname)) {
-        await getToken()
+        const token = await getToken()
+        if (!token) await logout()
       } else if (AUTH_PATHS.includes(router.pathname)) {
         try {
           await getToken({ redirect: false })

--- a/hooks/session.ts
+++ b/hooks/session.ts
@@ -56,7 +56,7 @@ export const useSession = () => {
       if (typeof window !== 'undefined') {
         logout()
         if (redirect) {
-          await router.push('/login')
+          if (!['/login', '/signup'].includes(router.pathname)) await router.push('/login')
         } else {
           throw new Error('Invalid credentials')
         }

--- a/hooks/session.ts
+++ b/hooks/session.ts
@@ -56,7 +56,7 @@ export const useSession = () => {
       if (typeof window !== 'undefined') {
         logout()
         if (redirect) {
-          if (!['/login', '/signup'].includes(router.pathname)) await router.push('/login')
+          //if (!['/login', '/signup'].includes(router.pathname)) await router.push('/login')
         } else {
           throw new Error('Invalid credentials')
         }

--- a/hooks/session.ts
+++ b/hooks/session.ts
@@ -55,12 +55,11 @@ export const useSession = () => {
       return accessToken
     } catch {
       if (typeof window !== 'undefined') {
-        if (redirect) {
-           return null
-        } else {
+        if (!redirect) {
           throw new Error('Invalid credentials')
         }
       }
+      return null
     }
   }
 

--- a/hooks/session.ts
+++ b/hooks/session.ts
@@ -55,14 +55,12 @@ export const useSession = () => {
       return accessToken
     } catch {
       if (typeof window !== 'undefined') {
-        //logout()
         if (redirect) {
-           // await router.push('/login')
+           return null
         } else {
           throw new Error('Invalid credentials')
         }
       }
-      return null
     }
   }
 

--- a/hooks/session.ts
+++ b/hooks/session.ts
@@ -34,7 +34,9 @@ export const useSession = () => {
   }
 
   const getToken = async (options?: GetTokenOptions) => {
-    const redirect = getValueFromOptions('redirect', options, true);
+    let redirect
+    if (!['/login', '/signup'].includes(router.pathname)) redirect = getValueFromOptions('redirect', options, true)
+    else redirect = false
     try {
       if (accessToken) {
         try {
@@ -56,7 +58,7 @@ export const useSession = () => {
       if (typeof window !== 'undefined') {
         logout()
         if (redirect) {
-          //if (!['/login', '/signup'].includes(router.pathname)) await router.push('/login')
+           await router.push('/login')
         } else {
           throw new Error('Invalid credentials')
         }

--- a/hooks/session.ts
+++ b/hooks/session.ts
@@ -28,15 +28,14 @@ export const useSession = () => {
     }
   }
 
-  const logout = () => {
+  const logout = async() => {
     setAccessToken(null)
     setRefreshToken(null)
+    await router.push('/login')
   }
 
   const getToken = async (options?: GetTokenOptions) => {
-    let redirect
-    if (!['/login', '/signup'].includes(router.pathname)) redirect = getValueFromOptions('redirect', options, true)
-    else redirect = false
+    const redirect = getValueFromOptions('redirect', options, true)
     try {
       if (accessToken) {
         try {
@@ -56,9 +55,9 @@ export const useSession = () => {
       return accessToken
     } catch {
       if (typeof window !== 'undefined') {
-        logout()
+        //logout()
         if (redirect) {
-           await router.push('/login')
+           // await router.push('/login')
         } else {
           throw new Error('Invalid credentials')
         }

--- a/hooks/session.ts
+++ b/hooks/session.ts
@@ -1,7 +1,6 @@
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 import { useRouter } from 'next/router'
 import * as api from '@/api'
-import { useLocalStorage } from '@/hooks/localStorage'
 
 export interface GetTokenOptions {
   redirect?: boolean

--- a/hooks/session.ts
+++ b/hooks/session.ts
@@ -35,7 +35,6 @@ export const useSession = () => {
   }
 
   const getToken = async (options?: GetTokenOptions) => {
-    const redirect = getValueFromOptions('redirect', options, true)
     try {
       if (accessToken) {
         try {
@@ -55,9 +54,7 @@ export const useSession = () => {
       return accessToken
     } catch {
       if (typeof window !== 'undefined') {
-        if (!redirect) {
-          throw new Error('Invalid credentials')
-        }
+        throw new Error('Invalid credentials')
       }
       return null
     }

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -8,9 +8,9 @@ import { RequireLoggedIn } from '@/components/guards/RequireLoggedIn'
 import '@/styles/globals.css'
 
 function MyApp(appProps: AppProps) {
-  const { getToken } = useSession()
+  const { getToken, logout } = useSession()
 
-  setupAPIAuthInterceptors(getToken);
+  setupAPIAuthInterceptors(getToken, logout);
 
   return <>
     <Provider store={store}>

--- a/pages/signup.tsx
+++ b/pages/signup.tsx
@@ -18,8 +18,7 @@ const Signup: NextPage = () => {
   const signUp = async (username: string, password: string, phoneNumber?: string) => {
     try {
       setLoading(true)
-      const resp = await api.user.create(username, phoneNumber || '', password)
-      console.log(resp)
+      await api.user.create(username, phoneNumber || '', password)
       await router.push('/login')
     } catch (error) {
       if (axios.isAxiosError(error)) {

--- a/pages/signup.tsx
+++ b/pages/signup.tsx
@@ -17,8 +17,9 @@ const Signup: NextPage = () => {
   const signUp = async (username: string, password: string, phoneNumber?: string) => {
     try {
       setLoading(true)
-      const response = await api.user.create(username, phoneNumber || '', password)
-      if (response) await router.push('/login')
+      await api.user.create(username, phoneNumber || '', password)
+      window.alert('signed up!')
+      router.push('/login')
     } catch (error) {
       if (axios.isAxiosError(error)) {
         const errorData = (error.response?.data || {}) as SignInError

--- a/pages/signup.tsx
+++ b/pages/signup.tsx
@@ -18,8 +18,8 @@ const Signup: NextPage = () => {
   const signUp = async (username: string, password: string, phoneNumber?: string) => {
     try {
       setLoading(true)
-      await api.user.create(username, phoneNumber || '', password)
-      await router.push('/login')
+      const response = await api.user.create(username, phoneNumber || '', password)
+      if (response) await router.push('/login')
     } catch (error) {
       if (axios.isAxiosError(error)) {
         const errorData = (error.response?.data || {}) as SignInError

--- a/pages/signup.tsx
+++ b/pages/signup.tsx
@@ -1,5 +1,5 @@
 import axios from 'axios'
-import { useState } from 'react'
+import { useRef, useState } from 'react'
 import type { NextPage } from 'next'
 import { useRouter } from 'next/router'
 import * as api from '@/api'
@@ -13,12 +13,14 @@ const Signup: NextPage = () => {
   const [phoneNumberError, setPhoneNumberError] = useState('')
   const [passwordError, setPasswordError] = useState('')
   const [loading, setLoading] = useState(false)
+  const mounted = useRef(false);
 
   const signUp = async (username: string, password: string, phoneNumber?: string) => {
     try {
       setLoading(true)
-      await api.user.create(username, phoneNumber || '', password)
-      router.push('/login')
+      const resp = await api.user.create(username, phoneNumber || '', password)
+      console.log(resp)
+      await router.push('/login')
     } catch (error) {
       if (axios.isAxiosError(error)) {
         const errorData = (error.response?.data || {}) as SignInError

--- a/pages/signup.tsx
+++ b/pages/signup.tsx
@@ -1,5 +1,5 @@
 import axios from 'axios'
-import { useRef, useState } from 'react'
+import { useState } from 'react'
 import type { NextPage } from 'next'
 import { useRouter } from 'next/router'
 import * as api from '@/api'
@@ -13,7 +13,6 @@ const Signup: NextPage = () => {
   const [phoneNumberError, setPhoneNumberError] = useState('')
   const [passwordError, setPasswordError] = useState('')
   const [loading, setLoading] = useState(false)
-  const mounted = useRef(false);
 
   const signUp = async (username: string, password: string, phoneNumber?: string) => {
     try {


### PR DESCRIPTION
- Se saca el manejo de redirect de get_token y se maneja aparte
- Se creo un response interceptor para el caso de recibir status 401 (acá se asume que el token que se mandó es invalido o no existe asi que se hace logout)

EDIT: en el ultimo commit traté de arreglar el login, funciona bien, pero reemplace el uso del custom hook useLocalStorage por manejar el local storage directamente dentro de useSesion.