### PR TITLE
Fix past my-rentals listing id

### DIFF
--- a/pages/my-rentals.tsx
+++ b/pages/my-rentals.tsx
@@ -7,41 +7,41 @@ import Image from 'next/image'
 import Link from 'next/link'
 
 const MyRentals: NextPage = () => {
-    const dispatch = useDispatch()
-    const { loading } = useSelector((state) => state.toolListings)
+  const dispatch = useDispatch()
+  const { loading } = useSelector((state) => state.toolListings)
 
-    const [toolListings, setToolListings] = useState<PastToolListing[]>([])
+  const [toolListings, setToolListings] = useState<PastToolListing[]>([])
 
-    useEffect(() => {
-      const loadListing = async () => {
-        const listings = await dispatch(loadMyRentals()).unwrap()
-        setToolListings(listings)
-      }
-      loadListing()
-    }, [dispatch])
+  useEffect(() => {
+    const loadListing = async () => {
+      const listings = await dispatch(loadMyRentals()).unwrap()
+      setToolListings(listings)
+    }
+    loadListing()
+  }, [dispatch])
 
-  return ( 
+  return (
     <div>
-      <div className=" m-24 bg-white shadow overflow-hidden sm:rounded-md text-center">
-        <div className="text-blue-800 font-bold text-2xl mb-2 m-10">
+      <div className="m-24 overflow-hidden text-center bg-white shadow  sm:rounded-md">
+        <div className="m-10 mb-2 text-2xl font-bold text-blue-800">
           Mi Historial de Arriendos
         </div>
         <div className="grid grid-cols-4 gap-8 m-10">
-          { loading ? <>loading...</> : toolListings.map((tool: PastToolListing) =>
-            <Link key={tool.id} href="/tools/[id]"  as={`/tools/${tool.id}`} passHref>
-              <div  className="max-w-sm rounded overflow-hidden shadow-lg">
+          {loading ? <>loading...</> : toolListings.map((tool: PastToolListing) =>
+            <Link key={tool.id} href="/tools/[id]" as={`/tools/${tool.listing}`} passHref>
+              <div className="max-w-sm overflow-hidden rounded shadow-lg">
                 <div className='relative w-full h-44'>
                   <Image alt={tool.name}
-                  className="rounded-t-lg"
-                  layout="fill" // required
-                  objectFit="cover"
-                  src={tool.image} />
+                    className="rounded-t-lg"
+                    layout="fill" // required
+                    objectFit="cover"
+                    src={tool.image} />
                 </div>
                 <div className="p-5">
-                  <div className="font-bold text-xl text-blue-800">{ tool.name }</div>
-                  <p className="text-sm text-gray-500">Precio: ${ tool.price }</p> 
+                  <div className="text-xl font-bold text-blue-800">{tool.name}</div>
+                  <p className="text-sm text-gray-500">Precio: ${tool.price}</p>
                 </div>
-              </div> 
+              </div>
             </Link>
           )}
         </div>


### PR DESCRIPTION
En la vista de my-rentals el link al listing se hace con el id del past tool listing, no con el del listing. Esta pr lo arregla.